### PR TITLE
GDAL-GRASS driver docs: added

### DIFF
--- a/docs/grass_raster.md
+++ b/docs/grass_raster.md
@@ -1,0 +1,66 @@
+# GDAL-GRASS driver: Raster Format
+
+GDAL optionally supports reading of existing GRASS GIS raster maps or
+imagery groups, but not writing or export. The support for GRASS raster
+format is determined when the library is configured, and requires
+libgrass to be pre-installed (see Notes below).
+
+GRASS raster maps/imagery groups can be selected in several ways.
+
+1.  The full path to the `cellhd` file can be specified. This is not a
+    relative path, or at least it must contain all the path components
+    within the GRASS database including the database root itself. The
+    following example opens the raster map "elevation" within the GRASS
+    mapset "PERMANENT" of the GRASS location "myloc" in the GRASS
+    database located at `/data/grassdb`.
+    
+    For example:
+    
+        gdalinfo /data/grassdb/myloc/PERMANENT/cellhd/elevation
+
+2.  The full path to the directory containing information about an
+    imagery group (or the REF file within it) can be specified to refer
+    to the whole group as a single dataset. The following examples do
+    the same thing.
+    
+    For example:
+    
+        gdalinfo /data/grassdb/imagery/raw/group/testmff/REF
+        gdalinfo /data/grassdb/imagery/raw/group/testmff
+
+3.  If there is a correct `.grassrc7/rc` (GRASS 7) setup file in the
+    user's home directory then raster maps or imagery groups may be
+    opened just by the cell or group name. This only works for raster
+    maps or imagery groups in the current GRASS location and mapset as
+    defined in the GRASS setup file.
+
+The following features are supported by the GDAL/GRASS link.
+
+  - Up to 256 entries from raster colormaps are read (0-255).
+  - Compressed and uncompressed integer (CELL), floating point (FCELL)
+    and double precision (DCELL) raster maps are all supported. Integer
+    raster maps are classified with a band type of "Byte" if the 1-byte
+    per pixel format is used, or "UInt16" if the two byte per pixel
+    format is used. Otherwise integer raster maps are treated as
+    "UInt32".
+  - Georeferencing information is properly read from GRASS format.
+  - An attempt is made to translate coordinate systems, but some
+    conversions may be flawed, in particular in handling of datums and
+    units.
+
+## Driver capabilities
+
+## Notes on driver variations
+
+The driver is able to use the GRASS GIS shared libraries directly
+instead of using libgrass (not recommended due to potentially circular
+dependencies). Currently both versions of the driver are available and
+can be configured using `--with-libgrass` for the libgrass variant or
+`--with-grass=<dir>` for the GRASS GIS library based version. The GRASS
+driver version currently does not support coordinate system access,
+though it is hoped that will be corrected at some point.
+
+## See Also
+
+  - [GRASS GIS home page](https://grass.osgeo.org)
+  - [old libgrass page](https://web.archive.org/web/20130730111701/http://home.gdal.org/projects/grass/)

--- a/docs/grass_raster.rst
+++ b/docs/grass_raster.rst
@@ -1,0 +1,83 @@
+.. _raster.grass:
+
+================================================================================
+GRASS Raster Format
+================================================================================
+
+.. shortname:: GRASS
+
+.. build_dependencies:: libgrass
+
+GDAL optionally supports reading of existing GRASS GIS raster maps or
+imagery groups, but not writing or export. The support for GRASS raster
+format is determined when the library is configured, and requires
+libgrass to be pre-installed (see Notes below).
+
+GRASS raster maps/imagery groups can be selected in several ways.
+
+#. The full path to the ``cellhd`` file can be specified. This is not a
+   relative path, or at least it must contain all the path components
+   within the GRASS database including the database root itself. The
+   following example opens the raster map "elevation" within the GRASS
+   mapset "PERMANENT" of the GRASS location "myloc" in the GRASS
+   database located at ``/data/grassdb``.
+
+   For example:
+
+   ::
+
+      gdalinfo /data/grassdb/myloc/PERMANENT/cellhd/elevation
+
+#. The full path to the directory containing information about an
+   imagery group (or the REF file within it) can be specified to refer
+   to the whole group as a single dataset. The following examples do the
+   same thing.
+
+   For example:
+
+   ::
+
+      gdalinfo /data/grassdb/imagery/raw/group/testmff/REF
+      gdalinfo /data/grassdb/imagery/raw/group/testmff
+
+#. If there is a correct ``.grassrc7/rc`` (GRASS 7) setup file in the
+   user's home directory then raster maps or imagery groups may be opened
+   just by the cell or group name.
+   This only works for raster maps or imagery groups in the
+   current GRASS location and mapset as defined in the GRASS setup file.
+
+The following features are supported by the GDAL/GRASS link.
+
+-  Up to 256 entries from raster colormaps are read (0-255).
+-  Compressed and uncompressed integer (CELL), floating point (FCELL)
+   and double precision (DCELL) raster maps are all supported. Integer
+   raster maps are classified with a band type of "Byte" if the 1-byte
+   per pixel format is used, or "UInt16" if the two byte per pixel
+   format is used. Otherwise integer raster maps are treated as
+   "UInt32".
+-  Georeferencing information is properly read from GRASS format.
+-  An attempt is made to translate coordinate systems, but some
+   conversions may be flawed, in particular in handling of datums and
+   units.
+
+Driver capabilities
+-------------------
+
+.. supports_georeferencing::
+
+Notes on driver variations
+--------------------------
+
+The driver is able to use the GRASS GIS shared libraries directly
+instead of using libgrass (not recommended due to potentially circular
+dependencies). Currently both versions of the driver are available and
+can be configured using ``--with-libgrass`` for the libgrass variant or
+``--with-grass=<dir>`` for the GRASS GIS library based version. The
+GRASS driver version currently does not support coordinate system
+access, though it is hoped that will be corrected at some point.
+
+See Also
+--------
+
+-  `GRASS GIS home page <https://grass.osgeo.org>`__
+-  `libgrass page <https://web.archive.org/web/20130730111701/http://home.gdal.org/projects/grass/>`__

--- a/docs/grass_vector.md
+++ b/docs/grass_vector.md
@@ -1,0 +1,113 @@
+# GDAL-GRASS driver: Vector Format
+
+The GDAL-GRASS driver can read GRASS (version 6.0 and higher) vector maps. Each
+GRASS vector map is represented as one datasource. A GRASS vector map
+may have 0, 1 or more layers.
+
+GRASS points are represented as wkbPoint, lines and boundaries as
+wkbLineString and areas as wkbPolygon. wkbMulti\* and
+wkbGeometryCollection are not used. More feature types can be mixed in
+one layer. If a layer contains only features of one type, it is set
+appropriately and can be retrieved by OGRLayer::GetLayerDefn();
+
+If a geometry has more categories of the same layer attached, its
+represented as more features (one for each category).
+
+Both 2D and 3D maps are supported.
+
+## Driver capabilities
+
+## Datasource name
+
+Datasource name is full path to 'head' file in GRASS vector directory.
+Using names of GRASS environment variables it can be expressed:
+
+    $GISDBASE/$LOCATION_NAME/$MAPSET/vector/mymap/head
+
+where 'mymap' is name of a vector map. For example:
+
+    /home/cimrman/grass_data/jizerky/jara/vector/liptakov/head
+
+## Layer names
+
+Usually layer numbers are used as layer names. Layer number 0 is used
+for all features without any category. It is possible to optionally give
+names to GRASS layers linked to database however currently this is not
+supported by grass modules. A layer name can be added in 'dbln' vector
+file as '/name' after layer number, for example to original record:
+
+    1 rivers cat $GISDBASE/$LOCATION_NAME/$MAPSET/dbf/ dbf
+
+it is possible to assign name 'rivers'
+
+    1/rivers rivers cat $GISDBASE/$LOCATION_NAME/$MAPSET/dbf/ dbf
+
+the layer 1 will be listed is layer 'rivers'.
+
+## Attribute filter
+
+If a layer has attributes stored in a database, the query is passed to
+the underlying database driver. That means, that SQL conditions which
+can be used depend on the driver and database to which the layer is
+linked. For example, DBF driver has currently very limited set of SQL
+expressions and PostgreSQL offers very rich set of SQL expressions.
+
+If a layer has no attributes linked and it has only categories, OGR
+internal SQL engine is used to evaluate the expression. Category is an
+integer number attached to geometry, it is sort of ID, but it is not FID
+as more features in one layer can have the same category.
+
+Evaluation is done once when the attribute filter is set.
+
+## Spatial filter
+
+Bounding boxes of features stored in topology structure are used to
+evaluate if a features matches current spatial filter.
+
+Evaluation is done once when the spatial filter is set.
+
+## GISBASE
+
+GISBASE is full path to the directory where GRASS is installed. By
+default, GRASS driver is using the path given to gdal configure script.
+A different directory can be forced by setting GISBASE environment
+variable. GISBASE is used to find GRASS database drivers.
+
+## Missing topology
+
+GRASS driver can read GRASS vector files if topology is available (AKA
+level 2). If an error is reported, telling that the topology is not
+available, it is necessary to build topology within GRASS using v.build
+module.
+
+## Random access
+
+If random access (GetFeature instead of GetNextFeature) is used on layer
+with attributes, the reading of features can be quite slow. It is
+because the driver has to query attributes by category for each feature
+(to avoid using a lot of memory) and random access to database is
+usually slow. This can be improved on GRASS side optimizing/writing file
+based (DBF, SQLite) drivers.
+
+## Known problem
+
+Because of bug in GRASS library, it is impossible to start/stop database
+drivers in FIFO order and FILO order must be used. The GRASS driver for
+OGR is written with this limit in mind and drivers are always closed if
+not used and if a driver remains opened kill() is used to terminate it.
+It can happen however in rare cases, that the driver will try to stop
+database driver which is not the last opened and an application hangs.
+This can happen if sequential read (GetNextFeature) of a layer is not
+finished (reading is stopped before last available feature is reached),
+features from another layer are read and then the reading of the first
+layer is finished, because in that case kill() is not used.
+
+## See Also
+
+  - [GRASS GIS home page](https://grass.osgeo.org)
+  - [old libgrass page](https://web.archive.org/web/20130730111701/http://home.gdal.org/projects/grass/)
+
+-----
+
+Development of this driver was financially supported by Faunalia
+([www.faunalia.it](http://www.faunalia.it/)).

--- a/docs/grass_vector.rst
+++ b/docs/grass_vector.rst
@@ -1,0 +1,139 @@
+.. _vector.grass:
+
+GRASS Vector Format
+===================
+
+.. shortname:: GRASS
+
+.. build_dependencies:: libgrass
+
+GRASS driver can read GRASS (version 6.0 and higher) vector maps. Each
+GRASS vector map is represented as one datasource. A GRASS vector map
+may have 0, 1 or more layers.
+
+GRASS points are represented as wkbPoint, lines and boundaries as
+wkbLineString and areas as wkbPolygon. wkbMulti\* and
+wkbGeometryCollection are not used. More feature types can be mixed in
+one layer. If a layer contains only features of one type, it is set
+appropriately and can be retrieved by OGRLayer::GetLayerDefn();
+
+If a geometry has more categories of the same layer attached, its
+represented as more features (one for each category).
+
+Both 2D and 3D maps are supported.
+
+Driver capabilities
+-------------------
+
+.. supports_georeferencing::
+
+Datasource name
+---------------
+
+Datasource name is full path to 'head' file in GRASS vector directory.
+Using names of GRASS environment variables it can be expressed:
+
+::
+
+      $GISDBASE/$LOCATION_NAME/$MAPSET/vector/mymap/head
+
+where 'mymap' is name of a vector map. For example:
+
+::
+
+      /home/cimrman/grass_data/jizerky/jara/vector/liptakov/head
+
+Layer names
+-----------
+
+Usually layer numbers are used as layer names. Layer number 0 is used
+for all features without any category. It is possible to optionally give
+names to GRASS layers linked to database however currently this is not
+supported by grass modules. A layer name can be added in 'dbln' vector
+file as '/name' after layer number, for example to original record:
+
+::
+
+   1 rivers cat $GISDBASE/$LOCATION_NAME/$MAPSET/dbf/ dbf
+
+it is possible to assign name 'rivers'
+
+::
+
+   1/rivers rivers cat $GISDBASE/$LOCATION_NAME/$MAPSET/dbf/ dbf
+
+the layer 1 will be listed is layer 'rivers'.
+
+Attribute filter
+----------------
+
+If a layer has attributes stored in a database, the query is passed to
+the underlying database driver. That means, that SQL conditions which
+can be used depend on the driver and database to which the layer is
+linked. For example, DBF driver has currently very limited set of SQL
+expressions and PostgreSQL offers very rich set of SQL expressions.
+
+If a layer has no attributes linked and it has only categories, OGR
+internal SQL engine is used to evaluate the expression. Category is an
+integer number attached to geometry, it is sort of ID, but it is not FID
+as more features in one layer can have the same category.
+
+Evaluation is done once when the attribute filter is set.
+
+Spatial filter
+--------------
+
+Bounding boxes of features stored in topology structure are used to
+evaluate if a features matches current spatial filter.
+
+Evaluation is done once when the spatial filter is set.
+
+GISBASE
+-------
+
+GISBASE is full path to the directory where GRASS is installed. By
+default, GRASS driver is using the path given to gdal configure script.
+A different directory can be forced by setting GISBASE environment
+variable. GISBASE is used to find GRASS database drivers.
+
+Missing topology
+----------------
+
+GRASS driver can read GRASS vector files if topology is available (AKA
+level 2). If an error is reported, telling that the topology is not
+available, it is necessary to build topology within GRASS using v.build
+module.
+
+Random access
+-------------
+
+If random access (GetFeature instead of GetNextFeature) is used on layer
+with attributes, the reading of features can be quite slow. It is
+because the driver has to query attributes by category for each feature
+(to avoid using a lot of memory) and random access to database is
+usually slow. This can be improved on GRASS side optimizing/writing file
+based (DBF, SQLite) drivers.
+
+Known problem
+-------------
+
+Because of bug in GRASS library, it is impossible to start/stop database
+drivers in FIFO order and FILO order must be used. The GRASS driver for
+OGR is written with this limit in mind and drivers are always closed if
+not used and if a driver remains opened kill() is used to terminate it.
+It can happen however in rare cases, that the driver will try to stop
+database driver which is not the last opened and an application hangs.
+This can happen if sequential read (GetNextFeature) of a layer is not
+finished (reading is stopped before last available feature is reached),
+features from another layer are read and then the reading of the first
+layer is finished, because in that case kill() is not used.
+
+See Also
+--------
+
+-  `GRASS GIS home page <http://grass.osgeo.org>`__
+
+--------------
+
+Development of this driver was financially supported by Faunalia
+(`www.faunalia.it <http://www.faunalia.it/>`__).


### PR DESCRIPTION
Moved original GDAL-GRASS driver documentation here from
- https://github.com/OSGeo/gdal/blob/master/doc/source/drivers/raster/grass.rst
- https://github.com/OSGeo/gdal/blob/master/doc/source/drivers/vector/grass.rst

Partially addresses https://github.com/OSGeo/gdal/issues/5667

Converted files to Markdown.