### PR TITLE
Support DESTDIR in install target.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -22,9 +22,9 @@ OLIBNAME =	ogr_GRASS.so
 default:	$(GLIBNAME) $(OLIBNAME)
 
 install:	default
-	install -d $(AUTOLOAD_DIR)
-	cp $(GLIBNAME) $(AUTOLOAD_DIR)
-	cp $(OLIBNAME) $(AUTOLOAD_DIR)
+	install -d $(DESTDIR)$(AUTOLOAD_DIR)
+	cp $(GLIBNAME) $(DESTDIR)$(AUTOLOAD_DIR)
+	cp $(OLIBNAME) $(DESTDIR)$(AUTOLOAD_DIR)
 
 clean:
 	rm -f $(OLIBNAME) $(GLIBNAME) *.o


### PR DESCRIPTION
The Debian package had to override `AUTOLOAD_DIR` for the install target to make it work without [`DESTDIR`](https://www.gnu.org/prep/standards/html_node/DESTDIR.html) support.

This patch makes that ugly hack obsolete.