### PR TITLE
Don't remove -g from C{,XX}FLAGS.

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -19,11 +19,6 @@ AC_DEFUN(AC_COMPILER_LOCALHACK,
 
 AC_DEFUN(AC_COMPILER_WFLAGS,
 [
-	# Remove -g from compile flags, we will add via CFG variable if
-	# we need it.
-	CXXFLAGS=`echo "$CXXFLAGS " | sed "s/-g //"`
-	CFLAGS=`echo "$CFLAGS " | sed "s/-g //"`
-
 	# check for GNU compiler, and use -Wall
 	if test "$GCC" = "yes"; then
 		C_WFLAGS="-Wall"


### PR DESCRIPTION
The Debian package lacks debug symbols because `-g` is stripped from `CFLAGS` & `CXXFLAGS`.

The CFG variable alluded to in the comment does not exist in `configure.in` nor `Makefile.in`.