### PR TITLE
Disable C++ symbol name mangling.

### DIFF
--- a/grass.cpp
+++ b/grass.cpp
@@ -53,6 +53,8 @@ extern "C" {
 char *GPJ_grass_to_wkt( const struct Key_Value *,
                         const struct Key_Value *,
                         int, int );
+
+void GDALRegister_GRASS();
 }
 
 #define GRASS_MAX_COLORS 100000  // what is the right value

--- a/ogrgrassdriver.cpp
+++ b/ogrgrassdriver.cpp
@@ -30,6 +30,10 @@
 #include "cpl_conv.h"
 #include "cpl_string.h"
 
+extern "C" {
+    void RegisterOGRGRASS();
+}
+
 CPL_CVSID("$Id$")
 
 /************************************************************************/


### PR DESCRIPTION
As reported in #9, using `gdalinfo` and `ogrinfo` results in `undefined symbol` errors.

Without these changes you get:
```
$ gdalinfo --version
ERROR 1: /usr/lib/x86_64-linux-gnu/gdalplugins/ogr_GRASS.so: undefined symbol: GDALRegisterMe
ERROR 1: /usr/lib/x86_64-linux-gnu/gdalplugins/ogr_GRASS.so: undefined symbol: RegisterOGRGRASS
ERROR 1: /usr/lib/x86_64-linux-gnu/gdalplugins/gdal_GRASS.so: undefined symbol: GDALRegisterMe
ERROR 1: /usr/lib/x86_64-linux-gnu/gdalplugins/gdal_GRASS.so: undefined symbol: GDALRegister_GRASS
GDAL 3.5.0, released 2022/05/10
```
```
$ ogrinfo --version
ERROR 1: /usr/lib/x86_64-linux-gnu/gdalplugins/ogr_GRASS.so: undefined symbol: GDALRegisterMe
ERROR 1: /usr/lib/x86_64-linux-gnu/gdalplugins/ogr_GRASS.so: undefined symbol: RegisterOGRGRASS
ERROR 1: /usr/lib/x86_64-linux-gnu/gdalplugins/gdal_GRASS.so: undefined symbol: GDALRegisterMe
ERROR 1: /usr/lib/x86_64-linux-gnu/gdalplugins/gdal_GRASS.so: undefined symbol: GDALRegister_GRASS
GDAL 3.5.0, released 2022/05/10
```

With these changes you the issue is resolved:
```
$ gdalinfo /tmp/nc_spm_08_grass7/PERMANENT/cellhd/aspect | head
Warning 1: GRASS warning: GISBASE environment variable was not set, using:
/usr/lib/grass82
Driver: GRASS/GRASS Rasters (7+)
Files: /tmp/nc_spm_08_grass7/PERMANENT/cellhd/aspect
Size is 1500, 1350
Coordinate System is:
PROJCRS["unknown",
    BASEGEOGCRS["grs80",
        DATUM["North American Datum 1983",
            ELLIPSOID["Geodetic_Reference_System_1980",6378137,298.257222101,
                LENGTHUNIT["metre",1]],
            ID["EPSG",6269]],
```
```
$ ogrinfo -ro -so /tmp/nc_spm_08_grass7/PERMANENT/vector/roadsmajor/head
Warning 1: GRASS warning: GISBASE environment variable was not set, using:
/usr/lib/grass82
INFO: Open of `/tmp/nc_spm_08_grass7/PERMANENT/vector/roadsmajor/head'
      using driver `OGR_GRASS' successful.
1: roadsmajor (Line String)
```