### PR TITLE
configure: Suppress test: -eq: unary operator expected warning

### DIFF
--- a/configure
+++ b/configure
@@ -3685,11 +3685,11 @@ if test x$ac_prog_cxx_stdcxx = xno
 then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CXX option to enable C++11 features" >&5
 printf %s "checking for $CXX option to enable C++11 features... " >&6; }
-if test ${ac_cv_prog_cxx_cxx11+y}
+if test ${ac_cv_prog_cxx_11+y}
 then :
   printf %s "(cached) " >&6
 else $as_nop
-  ac_cv_prog_cxx_cxx11=no
+  ac_cv_prog_cxx_11=no
 ac_save_CXX=$CXX
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -3731,11 +3731,11 @@ if test x$ac_prog_cxx_stdcxx = xno
 then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CXX option to enable C++98 features" >&5
 printf %s "checking for $CXX option to enable C++98 features... " >&6; }
-if test ${ac_cv_prog_cxx_cxx98+y}
+if test ${ac_cv_prog_cxx_98+y}
 then :
   printf %s "(cached) " >&6
 else $as_nop
-  ac_cv_prog_cxx_cxx98=no
+  ac_cv_prog_cxx_98=no
 ac_save_CXX=$CXX
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -4360,6 +4360,7 @@ GRASS_GISBASE=$GRASS_GISBASE
 
 
 # Scan GRASS_INCLUDE for USE_POSTGRES already enabled in GRASS GIS
+G_PG_ENABLED=0
 grep USE_POSTGRES $with_grass/include/Make/Platform.make | cut -d'=' -f2 | tr -s ' ' ' ' | cut -d' ' -f2 | grep 1 > /dev/null && G_PG_ENABLED=1
 # Scan for PG include path if enabled in GRASS GIS
 if test $G_PG_ENABLED -eq 1  ; then

--- a/configure.ac
+++ b/configure.ac
@@ -164,6 +164,7 @@ dnl Find PostgreSQL (GRASS GIS optional dependency)
 dnl ---------------------------------------------------------------------------
 
 # Scan GRASS_INCLUDE for USE_POSTGRES already enabled in GRASS GIS
+G_PG_ENABLED=0
 grep USE_POSTGRES $with_grass/include/Make/Platform.make | cut -d'=' -f2 | tr -s ' ' ' ' | cut -d' ' -f2 | grep 1 > /dev/null && G_PG_ENABLED=1
 # Scan for PG include path if enabled in GRASS GIS
 if test $G_PG_ENABLED -eq 1  ; then


### PR DESCRIPTION
This PR initializes `G_PG_ENABLED=0` to suppress a unary operator warning.