### PR TITLE
CI: create publishing workflow

### DIFF
--- a/.github/how_to_release.md
+++ b/.github/how_to_release.md
@@ -1,0 +1,26 @@
+# How to release gdal-grass
+
+1. Release tag must be created on CLI (letting GitHub create the tag in
+   connection with with GH online publish will **not** create and archive
+   the release files):
+
+```bash
+git switch main
+git pull
+git status
+
+# Set version, do not forget!
+version="x.y.z"
+
+# Assuming 'upstream' points to the OSGeo fork
+commit=$(git rev-parse HEAD)
+tag_message="gdal-grass ${version}"
+git tag -a -m "${tag_message}" $version $commit
+git push -u --tags upstream
+```
+
+2. Create a new release on GH, based on the above created tag. "Publish release"
+   will activate the *publish.yml* workflow, which will create and add the
+   packages to the release.
+
+3. Transfer the packaged files to https://download.osgeo.org/gdal-grass/.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+---
+name: Publish gdal-grass driver
+
+on:
+  release:
+    types: [published]
+env:
+  OUT_DIR: ${{ github.workspace }}/.g_outdir
+  GDAL-GRASS: gdal-grass-${{ github.ref_name }}
+permissions:
+  contents: write
+jobs:
+  build-n-publish:
+    name: Build and publish gdal-grass driver
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+      - name: Create tarballs
+        run: |
+          mkdir ${{ env.OUT_DIR }}
+          cd ..
+          tar -cvf ${{ env.OUT_DIR }}/${{ env.GDAL-GRASS }}.tar --exclude=".g*" gdal-grass
+          cd ${{ env.OUT_DIR }}
+          gzip -9k ${{ env.GDAL-GRASS }}.tar
+          md5sum ${{ env.GDAL-GRASS }}.tar.gz > ${{ env.GDAL-GRASS }}.tar.gz.md5
+          xz -9e ${{ env.GDAL-GRASS }}.tar
+          md5sum ${{ env.GDAL-GRASS }}.tar.xz > ${{ env.GDAL-GRASS }}.tar.xz.md5
+      - name: Publish distribution to GitHub
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+              ${{ env.OUT_DIR }}/${{ env.GDAL-GRASS }}.tar.gz
+              ${{ env.OUT_DIR }}/${{ env.GDAL-GRASS }}.tar.gz.md5
+              ${{ env.OUT_DIR }}/${{ env.GDAL-GRASS }}.tar.xz
+              ${{ env.OUT_DIR }}/${{ env.GDAL-GRASS }}.tar.xz.md5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,13 +26,17 @@ jobs:
           cd ${{ env.OUT_DIR }}
           gzip -9k ${{ env.GDAL-GRASS }}.tar
           md5sum ${{ env.GDAL-GRASS }}.tar.gz > ${{ env.GDAL-GRASS }}.tar.gz.md5
+          sha256sum ${{ env.GDAL-GRASS }}.tar.gz > ${{ env.GDAL-GRASS }}.tar.gz.sha256
           xz -9e ${{ env.GDAL-GRASS }}.tar
           md5sum ${{ env.GDAL-GRASS }}.tar.xz > ${{ env.GDAL-GRASS }}.tar.xz.md5
+          sha256sum ${{ env.GDAL-GRASS }}.tar.xz > ${{ env.GDAL-GRASS }}.tar.xz.sha256
       - name: Publish distribution to GitHub
         uses: softprops/action-gh-release@v1
         with:
           files: |
               ${{ env.OUT_DIR }}/${{ env.GDAL-GRASS }}.tar.gz
               ${{ env.OUT_DIR }}/${{ env.GDAL-GRASS }}.tar.gz.md5
+              ${{ env.OUT_DIR }}/${{ env.GDAL-GRASS }}.tar.gz.sha256
               ${{ env.OUT_DIR }}/${{ env.GDAL-GRASS }}.tar.xz
               ${{ env.OUT_DIR }}/${{ env.GDAL-GRASS }}.tar.xz.md5
+              ${{ env.OUT_DIR }}/${{ env.GDAL-GRASS }}.tar.xz.sha256


### PR DESCRIPTION
Adds GH workflow which on `publish`  creates tarball (and md5) files and adds them to the release.

One minor "caveat": the release tag need to be manually created. Letting GH create the tag upon release creation will not trigger the GH action. See added instruction file for procedure.

Fixes #18