### PR TITLE
Use GetGDALDriverManager to register driver

### DIFF
--- a/ogrgrassdriver.cpp
+++ b/ogrgrassdriver.cpp
@@ -96,5 +96,5 @@ void RegisterOGRGRASS()
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "GRASS Vectors (5.7+)" );
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/vector/grass.html" );
 
-    OGRSFDriverRegistrar::GetRegistrar()->RegisterDriver( poDriver );
+    GetGDALDriverManager()->RegisterDriver(poDriver);
 }


### PR DESCRIPTION
'GetRegistrar' and 'RegisterDriver' are deprecated.

Compilation issues the following warnings:

```
clang++-mp-devel -dynamiclib  grass.o -L/opt/local/lib/grass83/lib -lgrass_vector -lgrass_dig2 -lgrass_dgl -lgrass_rtree -lgrass_linkm -lgrass_dbmiclient -lgrass_dbmibase -lgrass_raster -lgrass_imagery -lgrass_gproj -lgrass_gmath -lgrass_gis -lgrass_datetime -lgrass_btree2 -lgrass_ccmath -L/opt/local/lib -lgdal  -o gdal_GRASS.so -Wl,-rpath,"/opt/local/lib/grass83/lib"
clang++-mp-devel -std=c++11 -Wall  -DUSE_CPL -DGRASS_GISBASE=\"/opt/local/lib/grass83\" -I/opt/local/include -I/opt/local/lib/grass83/include -I/opt/local/include/postgresql15 -I/opt/local/lib/proj9/include -g -O2 -c -o ogrgrassdriver.o ogrgrassdriver.cpp
ogrgrassdriver.cpp:99:27: warning: 'GetRegistrar' is deprecated: Use GDALDriverManager class instead [-Wdeprecated-declarations]
    OGRSFDriverRegistrar::GetRegistrar()->RegisterDriver( poDriver );
                          ^
/opt/local/include/ogrsf_frmts.h:546:9: note: 'GetRegistrar' has been explicitly marked deprecated here
        OGR_DEPRECATED("Use GDALDriverManager class instead");
        ^
/opt/local/include/ogrsf_frmts.h:49:27: note: expanded from macro 'OGR_DEPRECATED'
#define OGR_DEPRECATED(x) CPL_WARN_DEPRECATED(x)
                          ^
/opt/local/include/cpl_port.h:1052:47: note: expanded from macro 'CPL_WARN_DEPRECATED'
#define CPL_WARN_DEPRECATED(x) __attribute__((deprecated(x)))
                                              ^
ogrgrassdriver.cpp:99:43: warning: 'RegisterDriver' is deprecated: Use GDALDriverManager class instead [-Wdeprecated-declarations]
    OGRSFDriverRegistrar::GetRegistrar()->RegisterDriver( poDriver );
                                          ^
/opt/local/include/ogrsf_frmts.h:550:9: note: 'RegisterDriver' has been explicitly marked deprecated here
        OGR_DEPRECATED("Use GDALDriverManager class instead");
        ^
/opt/local/include/ogrsf_frmts.h:49:27: note: expanded from macro 'OGR_DEPRECATED'
#define OGR_DEPRECATED(x) CPL_WARN_DEPRECATED(x)
                          ^
/opt/local/include/cpl_port.h:1052:47: note: expanded from macro 'CPL_WARN_DEPRECATED'
#define CPL_WARN_DEPRECATED(x) __attribute__((deprecated(x)))
                                              ^
2 warnings generated.

```