### PR TITLE
CI: use ubuntugis-unstable for GRASS GIS 8 support

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -10,9 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Get dependencies
         run: |
+          sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable
           sudo apt-get update -y
           sudo apt-get install -y wget git gawk findutils
           xargs -a <(awk '! /^ *(#|$)/' ".github/workflows/apt.txt") -r -- \


### PR DESCRIPTION
Use
https://launchpad.net/~ubuntugis/+archive/ubuntu/ubuntugis-unstable

to avoid usage of grass78. See
https://github.com/OSGeo/gdal-grass/actions/runs/6079612931/job/16492347829?pr=30

```
...
 extracting: nc_spm_08_micro/PERMANENT/cell/aspect
 inflating: nc_spm_08_micro/PERMANENT/cell/basin_50K
 extracting: nc_spm_08_micro/PERMANENT/cell/slope
 extracting: nc_spm_08_micro/PERMANENT/cell/elevation
 inflating: nc_spm_08_micro/PERMANENT/PROJ_UNITS
+ rm -f nc_spm_08_micro.zip
++ grass --config path
+ export LD_LIBRARY_PATH=/usr/lib/grass78/lib
+ LD_LIBRARY_PATH=/usr/lib/grass78/lib
...
```