### PR TITLE
cmake: fix configure of Proj and PostgreSQL in standard locations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,8 +53,8 @@ add_library(gdal_grass SHARED ${GLIB_SOURCES})
 set_target_properties(gdal_grass PROPERTIES PREFIX "")
 set_target_properties(gdal_grass PROPERTIES OUTPUT_NAME "gdal_GRASS")
 target_include_directories(
-  gdal_grass PRIVATE ${CMAKE_SOURCE_DIR} ${GDAL_INCLUDE_DIR} ${PQ_INCLUDE}
-                     ${GRASS_INCLUDE} ${PROJINC})
+  gdal_grass PRIVATE ${CMAKE_SOURCE_DIR} ${GDAL_INCLUDE_DIR} ${PostgreSQL_INCLUDE_DIRS}
+                     ${GRASS_INCLUDE} ${PROJ_INCLUDE_DIRS})
 target_link_libraries(gdal_grass PUBLIC ${GDAL_LIBRARY} ${G_LIBS})
 install(TARGETS gdal_grass DESTINATION ${AUTOLOAD_DIR})
 
@@ -62,8 +62,8 @@ add_library(ogr_grass SHARED ${OLIB_SOURCES})
 set_target_properties(ogr_grass PROPERTIES PREFIX "")
 set_target_properties(ogr_grass PROPERTIES OUTPUT_NAME "ogr_GRASS")
 target_include_directories(
-  ogr_grass PRIVATE ${CMAKE_SOURCE_DIR} ${GDAL_INCLUDE_DIR} ${PQ_INCLUDE}
-                    ${GRASS_INCLUDE} ${PROJINC})
+  ogr_grass PRIVATE ${CMAKE_SOURCE_DIR} ${GDAL_INCLUDE_DIR} ${PostgreSQL_INCLUDE_DIRS}
+                    ${GRASS_INCLUDE} ${PROJ_INCLUDE_DIRS})
 target_link_libraries(ogr_grass PUBLIC ${GDAL_LIBRARY} ${G_LIBS})
 install(TARGETS ogr_grass DESTINATION ${AUTOLOAD_DIR})
 

--- a/cmake/FindPROJ.cmake
+++ b/cmake/FindPROJ.cmake
@@ -1,20 +1,52 @@
 #[=======================================================================[.rst:
 FindPROJ
---------------
+--------
 
 Find PROJ's include path.
+
+Result variables
+^^^^^^^^^^^^^^^^
+
+This module will set the following variables in your project:
+
+``PROJ_INCLUDE_DIRS``
+  the directories of the PROJ headers (proj.h etc.)
+``PROJ_FOUND``
+  True if PROJ is found.
+
+Hints
+^^^^^
+
+Set ``PROJ_INCLUDE_DIR`` environment variable to specify the location of
+non-standard location of PROJ include directory.
+
 #]=======================================================================]
 
 include(${CMAKE_SOURCE_DIR}/cmake/GRASSUtilities.cmake)
 
-set(PROJINC "")
+set(PROJ_INCLUDE_DIRS)
+set(PROJ_FOUND)
 
-get_grass_platform_var("${GRASS_GISBASE}/include/Make/Platform.make" "PROJINC"
-                       PROJINC)
+if(PROJ_INCLUDE_DIR)
+  # if PROJ_INCLUDE_DIR is explicitly set, use it
+  set(PROJ_INCLUDE_DIRS ${PROJ_INCLUDE_DIR})
+  set(PROJ_FOUND TRUE)
+else()
+  # try to use GRASS' settings
+  get_grass_platform_var("${GRASS_GISBASE}/include/Make/Platform.make" "PROJINC" PROJ_INCLUDE_DIRS)
+  if(PROJ_INCLUDE_DIRS)
+    string(REGEX REPLACE "-I(.*)" "\\1" PROJ_INCLUDE_DIRS "${PROJ_INCLUDE_DIRS}")
+    set(PROJ_FOUND TRUE)
+  endif()
+endif()
 
-if(NOT "${PROJINC}" STREQUAL "")
-  string(REGEX REPLACE "-I(.*)" "\\1" PROJINC "${PROJINC}")
+if(NOT PROJ_FOUND)
+  find_package(PROJ CONFIG)
+endif()
+
+if(NOT PROJ_FOUND)
+  find_path(PROJ_INCLUDE_DIRS NAMES proj_api.h proj.h)
 endif()
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(PROJ REQUIRED_VARS PROJINC)
+find_package_handle_standard_args(PROJ REQUIRED_VARS PROJ_INCLUDE_DIRS PROJ_FOUND)

--- a/cmake/FindPostgreSQL.cmake
+++ b/cmake/FindPostgreSQL.cmake
@@ -3,26 +3,94 @@ FindPostgreSQL
 --------------
 
 Find PostgreSQL's include path.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This module will set the following variables in your project:
+
+``PostgreSQL_FOUND``
+  True if PostgreSQL is found.
+``PostgreSQL_INCLUDE_DIRS``
+  the directories of the PostgreSQL headers
+
+Hints
+^^^^^
+
+Set ``PostgreSQL_INCLUDE_DIR`` environment variable to specify the location of
+non-standard location of PostgreSQL include directory.
+
 #]=======================================================================]
 
+# check out GRASS' settings
 include(${CMAKE_SOURCE_DIR}/cmake/GRASSUtilities.cmake)
-
-set(PQ_INCLUDE "")
-
-get_grass_platform_var("${GRASS_GISBASE}/include/Make/Platform.make"
-                       "PQINCPATH" PQINCPATH)
-get_grass_platform_var("${GRASS_GISBASE}/include/Make/Platform.make"
-                       "USE_POSTGRES" USE_POSTGRES)
-
-if(NOT "${PQINCPATH}" STREQUAL "")
+get_grass_platform_var("${GRASS_GISBASE}/include/Make/Platform.make" "PQINCPATH" PQINCPATH)
+get_grass_platform_var("${GRASS_GISBASE}/include/Make/Platform.make" "USE_POSTGRES" USE_POSTGRES)
+if(PQINCPATH)
   string(REGEX REPLACE "-I(.*)" "\\1" PQINCPATH "${PQINCPATH}")
 endif()
 
-if(USE_POSTGRES)
-  set(PQ_INCLUDE ${PQINCPATH})
-elseif(POSTGRES_INCLUDES_DIR)
-  set(PQ_INCLUDE ${POSTGRES_INCLUDES_DIR})
+if(PostgreSQL_INCLUDE_DIR)
+  # if PostgreSQL_INCLUDE_DIR is explicitly set, use it
+  set(PostgreSQL_FOUND TRUE)
+elseif(USE_POSTGRES AND PQINCPATH)
+  # Use GRASS' settings
+  set(PostgreSQL_INCLUDE_DIR ${PQINCPATH})
+  set(PostgreSQL_FOUND TRUE)
+endif()
+
+if(NOT PostgreSQL_FOUND)
+  set(PostgreSQL_KNOWN_VERSIONS ${PostgreSQL_ADDITIONAL_VERSIONS}
+      "16" "15" "14" "13" "12" "11" "10" "9.6" "9.5" "9.4" "9.3" "9.2" "9.1" "9.0" "8.4" "8.3" "8.2" "8.1" "8.0")
+
+  # Define additional search paths for root directories.
+  set( PostgreSQL_ROOT_DIRECTORIES
+     ENV PostgreSQL_ROOT
+     ${PostgreSQL_ROOT}
+  )
+  foreach(suffix ${PostgreSQL_KNOWN_VERSIONS})
+    if(WIN32)
+      list(APPEND PostgreSQL_LIBRARY_ADDITIONAL_SEARCH_SUFFIXES
+          "PostgreSQL/${suffix}/lib")
+      list(APPEND PostgreSQL_INCLUDE_ADDITIONAL_SEARCH_SUFFIXES
+          "PostgreSQL/${suffix}/include")
+      list(APPEND PostgreSQL_TYPE_ADDITIONAL_SEARCH_SUFFIXES
+          "PostgreSQL/${suffix}/include/server")
+    endif()
+    if(UNIX)
+      list(APPEND PostgreSQL_LIBRARY_ADDITIONAL_SEARCH_SUFFIXES
+          "postgresql${suffix}"
+          "postgresql@${suffix}"
+          "pgsql-${suffix}/lib")
+      list(APPEND PostgreSQL_INCLUDE_ADDITIONAL_SEARCH_SUFFIXES
+          "postgresql${suffix}"
+          "postgresql@${suffix}"
+          "postgresql/${suffix}"
+          "pgsql-${suffix}/include")
+      list(APPEND PostgreSQL_TYPE_ADDITIONAL_SEARCH_SUFFIXES
+          "postgresql${suffix}/server"
+          "postgresql@${suffix}/server"
+          "postgresql/${suffix}/server"
+          "pgsql-${suffix}/include/server")
+    endif()
+  endforeach()
+
+  find_path(PostgreSQL_INCLUDE_DIR
+    NAMES libpq-fe.h
+    PATHS
+     # Look in other places.
+     ${PostgreSQL_ROOT_DIRECTORIES}
+    PATH_SUFFIXES
+      pgsql
+      postgresql
+      include
+      ${PostgreSQL_INCLUDE_ADDITIONAL_SEARCH_SUFFIXES}
+  )
 endif()
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(PostgreSQL REQUIRED_VARS PQ_INCLUDE)
+find_package_handle_standard_args(PostgreSQL REQUIRED_VARS PostgreSQL_INCLUDE_DIR PostgreSQL_FOUND)
+
+if(PostgreSQL_FOUND)
+  set(PostgreSQL_INCLUDE_DIRS ${PostgreSQL_INCLUDE_DIR})
+endif()


### PR DESCRIPTION
Fix CMake configure of Proj and PostgreSQL in standard locations. Accounting for non-existing entries in GRASS' Platform.make file.

Closes #41