### PR TITLE
CI: create release draft on tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,26 +1,59 @@
 ---
-name: Publish gdal-grass driver
+name: Create or check a release draft
 
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - main
+    tags:
+      - '**'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/**
+      - utils/**
 env:
-  OUT_DIR: ${{ github.workspace }}/.g_outdir
+  OUT_DIR: ${{ github.workspace }}/../g_outdir
   GDAL-GRASS: gdal-grass-${{ github.ref_name }}
 permissions:
   contents: write
 jobs:
   build-n-publish:
-    name: Build and publish gdal-grass driver
+    name: Package and create release draft
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
           ref: ${{ github.ref }}
-      - name: Create tarballs
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install PyYAML
+      - name: Create output directory
         run: |
           mkdir ${{ env.OUT_DIR }}
+      - name: Generate ChangeLog file
+        run: |
+          lasttag=""
+          for tag in $(git tag -n --sort=-creatordate | cut -d' ' -f 1); do
+              if [[ $tag != *"RC"* && $tag != ${{ github.ref_name }} ]]; then
+                  lasttag="$tag"
+                  break
+              fi
+          done
+          echo "Creating CHANGELOG since v$lasttag"
+          echo "$(python ./utils/generate_release_notes.py log main \
+              $lasttag ${{ github.ref_name }})" >> ${{ env.OUT_DIR }}/CHANGELOG
+      - name: Create tarballs (for tags only)
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
           cd ..
           tar -cvf ${{ env.OUT_DIR }}/${{ env.GDAL-GRASS }}.tar --exclude=".g*" gdal-grass
           cd ${{ env.OUT_DIR }}
@@ -30,9 +63,14 @@ jobs:
           xz -9e ${{ env.GDAL-GRASS }}.tar
           md5sum ${{ env.GDAL-GRASS }}.tar.xz > ${{ env.GDAL-GRASS }}.tar.xz.md5
           sha256sum ${{ env.GDAL-GRASS }}.tar.xz > ${{ env.GDAL-GRASS }}.tar.xz.sha256
-      - name: Publish distribution to GitHub
+      - name: Publish draft release to GitHub (for tags only)
+        if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
+          name: GDAL-GRASS GIS driver ${{ github.ref_name }}
+          body_path: ${{ env.OUT_DIR }}/CHANGELOG
+          draft: true
+          prerelease: ${{ contains(github.ref, 'RC') }}
           files: |
               ${{ env.OUT_DIR }}/${{ env.GDAL-GRASS }}.tar.gz
               ${{ env.OUT_DIR }}/${{ env.GDAL-GRASS }}.tar.gz.md5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,12 +24,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           python-version: '3.11'
       - name: Install Python dependencies
@@ -55,7 +55,8 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         run: |
           cd ..
-          tar -cvf ${{ env.OUT_DIR }}/${{ env.GDAL-GRASS }}.tar --exclude=".g*" gdal-grass
+          tar -cvf ${{ env.OUT_DIR }}/${{ env.GDAL-GRASS }}.tar --exclude=".g*" \
+            --transform s/gdal-grass/${{ env.GDAL-GRASS }}/ gdal-grass
           cd ${{ env.OUT_DIR }}
           gzip -9k ${{ env.GDAL-GRASS }}.tar
           md5sum ${{ env.GDAL-GRASS }}.tar.gz > ${{ env.GDAL-GRASS }}.tar.gz.md5
@@ -65,7 +66,7 @@ jobs:
           sha256sum ${{ env.GDAL-GRASS }}.tar.xz > ${{ env.GDAL-GRASS }}.tar.xz.sha256
       - name: Publish draft release to GitHub (for tags only)
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2.1.0
         with:
           name: GDAL-GRASS GIS driver ${{ github.ref_name }}
           body_path: ${{ env.OUT_DIR }}/CHANGELOG

--- a/utils/generate_release_notes.py
+++ b/utils/generate_release_notes.py
@@ -103,7 +103,7 @@ def print_notes(
     """
     num_changes = round_down_to_five(len(changes))
     print(
-        f"The gdal-grass {end_tag} release provides more than "
+        f"The GDAL-GRASS driver {end_tag} release provides more than "
         f"{num_changes} improvements and fixes "
         f"with respect to the release {start_tag}.\n"
     )


### PR DESCRIPTION
Update the publishing workflow to create a release draft, triggered by a pushed tag (working in a similar way as GRASS repo). Changelog is generated and added. 
See bogus release [example](https://github.com/nilason/gdal-grass/releases/tag/untagged-ce7a10d839439c9b30b9).