### PR TITLE
Set RUNPATH for grass libraries in non-standard library path.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ set(OLIB_SOURCES ogrgrassdriver.cpp ogrgrassdatasource.cpp ogrgrasslayer.cpp ogr
 add_library(gdal_grass SHARED ${GLIB_SOURCES})
 set_target_properties(gdal_grass PROPERTIES PREFIX "")
 set_target_properties(gdal_grass PROPERTIES OUTPUT_NAME "gdal_GRASS")
+set_target_properties(gdal_grass PROPERTIES INSTALL_RPATH "${GRASS_GISBASE}/lib")
 target_include_directories(
   gdal_grass PRIVATE ${CMAKE_SOURCE_DIR} ${GDAL_INCLUDE_DIR} ${PostgreSQL_INCLUDE_DIRS}
                      ${GRASS_INCLUDE} ${PROJ_INCLUDE_DIRS})
@@ -61,6 +62,7 @@ install(TARGETS gdal_grass DESTINATION ${AUTOLOAD_DIR})
 add_library(ogr_grass SHARED ${OLIB_SOURCES})
 set_target_properties(ogr_grass PROPERTIES PREFIX "")
 set_target_properties(ogr_grass PROPERTIES OUTPUT_NAME "ogr_GRASS")
+set_target_properties(ogr_grass PROPERTIES INSTALL_RPATH "${GRASS_GISBASE}/lib")
 target_include_directories(
   ogr_grass PRIVATE ${CMAKE_SOURCE_DIR} ${GDAL_INCLUDE_DIR} ${PostgreSQL_INCLUDE_DIRS}
                     ${GRASS_INCLUDE} ${PROJ_INCLUDE_DIRS})


### PR DESCRIPTION
The CMake build doesn't set the library RUNPATH as the Autotools does for the GRASS libraries in non-standard library paths like those used by the Debian package.

Autotools:
```bash
-Wl,-rpath,"@GRASS_GISBASE@/lib"
```

CMake:
```cmake
set_target_properties(gdal_grass PROPERTIES INSTALL_RPATH "${GRASS_GISBASE}/lib")
```